### PR TITLE
fix: pin black to 23.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-slim
 ENV PYTHONDONTWRITEBYTECODE 1 \
     PYTHONUNBUFFERED 1
 
-RUN  python -m venv venv && . venv/bin/activate &&  pip install --upgrade pip && venv/bin/pip install --upgrade --no-cache-dir black
+RUN  python -m venv venv && . venv/bin/activate &&  pip install --upgrade pip && venv/bin/pip install --upgrade --no-cache-dir black==23.11.0
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This commit temporary pins black to 23.11.0 since version https://github.com/psf/black/releases/tag/23.12.0
breaks this action (see #18).
